### PR TITLE
Updated to llama.cpp b5ed0e058c98645c1cab752d012fdc4be22bceef

### DIFF
--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -22,7 +22,7 @@
       With the higher-level APIs and RAG support, it's convenient to deploy LLM (Large Language Model) in your application with LLamaSharp.
     </Description>
     <PackageReleaseNotes>
-        Updated llama.cpp version to 506bb6e01009058f35558474cf987eeb56361782
+        Updated llama.cpp version to b5ed0e058c98645c1cab752d012fdc4be22bceef
     </PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageOutputPath>packages</PackageOutputPath>
@@ -57,7 +57,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <BinaryReleaseId>ff4affb4c1aa7eb4_v3</BinaryReleaseId>
+    <BinaryReleaseId>b5ed0e0</BinaryReleaseId>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -68,7 +68,7 @@
   <!-- When UnzipReleaseBinaries is called, this will run first, as UnzipReleaseBinaries depends on it (check DependsOnTargets of UnzipReleaseBinaries) -->
   <Target Name="DownloadReleaseBinaries">
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
-      <DownloadFile SourceUrl="https://github.com/SciSharp/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip" DestinationFolder="runtimes" DestinationFileName="deps.zip" SkipUnchangedFiles="true" Retries="3" />
+      <DownloadFile SourceUrl="https://github.com/m0nsky/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip" DestinationFolder="runtimes" DestinationFileName="deps.zip" SkipUnchangedFiles="true" Retries="3" />
   </Target>
 
   <!-- This automatically runs after CheckReleaseBinaries has completed, but only if SkipDownloadReleaseBinaries is not true -->

--- a/LLama/Native/LLamaModelQuantizeParams.cs
+++ b/LLama/Native/LLamaModelQuantizeParams.cs
@@ -80,6 +80,16 @@ namespace LLama.Native
         private sbyte _keep_split;
 
         /// <summary>
+        /// calculate and show the final quantization size without performing quantization
+        /// </summary>
+        public bool dry_run
+        {
+            get => Convert.ToBoolean(_dry_run);
+            set => _dry_run = Convert.ToSByte(value);
+        }
+        private sbyte _dry_run;
+
+        /// <summary>
         /// pointer to importance matrix data
         /// </summary>
         public IntPtr imatrix;


### PR DESCRIPTION
# Binary Update Summary

## Commits
- **Old:** ff4affb4c1aa7eb4f28a0d9de1b205bd719802f2
- **New:** b5ed0e058c98645c1cab752d012fdc4be22bceef

## llama.h Changes

### New struct fields
- `bool dry_run` added to `llama_model_quantize_params` — calculate and show the final quantization size without performing quantization

### Comment typo fixes (no code impact)
- "indicies" → "indices" in `llama_get_logits_ith` and `llama_get_embeddings_ith`
- "probabilites" → "probabilities" in `llama_get_sampled_probs_ith`
- "Intializes" → "Initializes" in GBNF grammar sampler docs

## ggml.h Changes

### Removed functions
- `ggml_type_sizef` removed (was already deprecated) — not bound in C#

### New functions
- `ggml_is_view` added — not bound in C#

### Comment typo fixes
- "mutiple" → "multiple"

## ggml-backend.h Changes

### Comment typo fixes only
- "preferrably" → "preferably"

## ggml-opt.h Changes

### Comment typo fixes only
- "initilize" → "initialize"

## C# Changes Made

### Modified files
1. `LLama/Native/LLamaModelQuantizeParams.cs` — Added `bool dry_run` field (sbyte backing pattern) between `keep_split` and `imatrix`
2. `LLama/LLamaSharp.csproj` — Updated BinaryReleaseId, download URL, and PackageReleaseNotes
3. `llama.cpp` submodule — Updated to new commit

## Test Results
- **Total:** 112
- **Passed:** 111
- **Skipped:** 1
- **Failed:** 0
- All NativeAbiTests passed (struct layouts verified)